### PR TITLE
Added max_pixels option

### DIFF
--- a/js/sketch.js
+++ b/js/sketch.js
@@ -669,14 +669,21 @@ var Sketch = (function() {
     }
 
     function resize( event ) {
-
+        var aspect_ratio, num_pixels, new_height;
         var target = ctx.type === DOM ? ctx.style : ctx.canvas;
-
         if ( ctx.fullscreen ) {
-
-            ctx.height = target.height = window.innerHeight;
-            ctx.width = target.width = window.innerWidth;
-
+            num_pixels = window.innerWidth * window.innerHeight;
+            if (ctx.max_pixels && num_pixels > ctx.max_pixels){
+                aspect_ratio = window.innerWidth / window.innerHeight;
+                new_height = Math.sqrt(ctx.max_pixels / aspect_ratio);
+                ctx.height = target.height = new_height;
+                ctx.width  = target.width  = new_height * aspect_ratio;
+                target.style.height = window.innerHeight + 'px';
+                target.style.width = window.innerWidth + 'px';
+            } else {
+                ctx.height = target.height = window.innerHeight;
+                ctx.width  = target.width  = window.innerWidth;
+            }
         } else {
 
             target.height = ctx.height;


### PR DESCRIPTION
Rendering can get a little slow if you're running a game fullscreen on a high resolution display, so I added an option to set the max_pixels you are willing to render. When set, sketch limits how high it sets the canvas and drawing context width and height to numbers so that the total number of pixels does not exceed this number. The scaling is then handled with .style.height and .style.width instead, so that stuff can still be fullscreen.

It is off by default.
