### PR TITLE
Added center.x and center.y to sketch context

### DIFF
--- a/js/sketch.js
+++ b/js/sketch.js
@@ -148,6 +148,11 @@ var Sketch = (function() {
             dx: 0.0, dy: 0.0
         };
 
+		var center = {
+			x: context.width / 2,
+			y: context.height / 2
+		};
+
         var eventMap = [
 
             context.element,
@@ -248,6 +253,9 @@ var Sketch = (function() {
 
                 context.scale( ratio, ratio );
             }
+
+            context.center.x = context.width / 2;
+            context.center.y = context.height / 2;
 
             if ( setup ) trigger( context.resize );
         }
@@ -393,6 +401,7 @@ var Sketch = (function() {
             touches: touches,
             mouse: mouse,
             keys: keys,
+            center: center,
 
             dragging: false,
             running: false,


### PR DESCRIPTION
Hi Justin - 

I'm having a blast playing around with sketch.js!
I found that I often end up defining a 'resize' method simply to set center.x and center.y properties on the context so I thought I'd add it. I'm fairly new to pull requests, so please let me know if there's something I should do differently. Also note that I did not update the minified version with my change.

Thanks for all the inspiration : )
Cheers!
