### PR TITLE
Use pageXOffset as fallback

### DIFF
--- a/js/sketch.js
+++ b/js/sketch.js
@@ -269,8 +269,8 @@ var Sketch = (function() {
 
             bounds = target.getBoundingClientRect();
 
-            touch.x = touch.pageX - bounds.left - win.scrollX;
-            touch.y = touch.pageY - bounds.top - win.scrollY;
+            touch.x = touch.pageX - bounds.left - (win.scrollX || win.pageXOffset);
+            touch.y = touch.pageY - bounds.top - (win.scrollY || win.pageYOffset);
 
             return touch;
         }


### PR DESCRIPTION
This should fix issue #55

IE9 & IE10 do not have the alias scrollX/Y
pageXOffset seems the original and standard property. See https://developer.mozilla.org/en-US/docs/Web/API/Window.scrollX

Maybe it could be used alone, not as a fallback for scrollX/Y
