### PR TITLE
Fix dom ready issue

### DIFF
--- a/examples/drawing.html
+++ b/examples/drawing.html
@@ -8,6 +8,57 @@
                 background: #F51E50;
             }
         </style>
+        <script src="../js/sketch.js"></script>
+        <script>
+        var COLOURS = [ '#E3EB64', '#A7EBCA', '#FFFFFF', '#D8EBA7', '#868E80' ];
+        var radius = 0;
+
+        window.addEventListener('DOMContentLoaded', run);
+
+        function run() {
+            Sketch.create({
+
+                container: document.getElementById( 'container' ),
+                autoclear: false,
+
+                setup: function() {
+                    console.log( 'setup' );
+                },
+
+                update: function() {
+                    radius = 2 + abs( sin( this.millis * 0.003 ) * 50 );
+                },
+
+                // Event handlers
+
+                keydown: function() {
+                    if ( this.keys.C ) this.clear();
+                },
+
+                // Mouse & touch events are merged, so handling touch events by default
+                // and powering sketches using the touches array is recommended for easy
+                // scalability. If you only need to handle the mouse / desktop browsers,
+                // use the 0th touch element and you get wider device support for free.
+                touchmove: function() {
+
+                    for ( var i = this.touches.length - 1, touch; i >= 0; i-- ) {
+
+                        touch = this.touches[i];
+
+                        this.lineCap = 'round';
+                        this.lineJoin = 'round';
+                        this.fillStyle = this.strokeStyle = COLOURS[ i % COLOURS.length ];
+                        this.lineWidth = radius;
+
+                        this.beginPath();
+                        this.moveTo( touch.ox, touch.oy );
+                        this.lineTo( touch.x, touch.y );
+                        this.stroke();
+                    }
+                }
+            });
+        }
+        </script>
     </head>
     <body>
         <div id="container"></div>
@@ -22,54 +73,5 @@
                 <a href="https://github.com/soulwire/sketch.js" target="_blank">View on Github</a>
             </nav>
         </header>
-        <script src="../js/sketch.js"></script>
-        <script>
-
-        var COLOURS = [ '#E3EB64', '#A7EBCA', '#FFFFFF', '#D8EBA7', '#868E80' ];
-        var radius = 0;
-
-        Sketch.create({
-
-            container: document.getElementById( 'container' ),
-            autoclear: false,
-
-            setup: function() {
-                console.log( 'setup' );
-            },
-
-            update: function() {
-                radius = 2 + abs( sin( this.millis * 0.003 ) * 50 );
-            },
-
-            // Event handlers
-
-            keydown: function() {
-                if ( this.keys.C ) this.clear();
-            },
-
-            // Mouse & touch events are merged, so handling touch events by default
-            // and powering sketches using the touches array is recommended for easy
-            // scalability. If you only need to handle the mouse / desktop browsers,
-            // use the 0th touch element and you get wider device support for free.
-            touchmove: function() {
-
-                for ( var i = this.touches.length - 1, touch; i >= 0; i-- ) {
-
-                    touch = this.touches[i];
-
-                    this.lineCap = 'round';
-                    this.lineJoin = 'round';
-                    this.fillStyle = this.strokeStyle = COLOURS[ i % COLOURS.length ];
-                    this.lineWidth = radius;
-
-                    this.beginPath();
-                    this.moveTo( touch.ox, touch.oy );
-                    this.lineTo( touch.x, touch.y );
-                    this.stroke();
-                }
-            }
-        });
-        
-        </script>
     </body>
 </html>

--- a/js/sketch.js
+++ b/js/sketch.js
@@ -6,20 +6,20 @@
     if ( typeof exports === 'object' ) {
 
         // CommonJS like
-        module.exports = factory(root, root.document);
+        module.exports = factory(root);
 
     } else if ( typeof define === 'function' && define.amd ) {
 
         // AMD
-        define( function() { return factory( root, root.document ); });
+        define( function() { return factory(root); });
 
     } else {
 
         // Browser global
-        root.Sketch = factory( root, root.document );
+        root.Sketch = factory(root);
     }
 
-}( this, function ( window, document ) {
+}( this, function (win) {
 
     "use strict";
 
@@ -39,18 +39,14 @@
     var WEBGL = 'webgl';
     var DOM = 'dom';
 
-    var doc = document;
-    var win = window;
-
     var instances = [];
 
     var defaults = {
-
         fullscreen: true,
         autostart: true,
         autoclear: true,
         autopause: true,
-        container: doc.body,
+        container: false,
         interval: 1,
         globals: true,
         retina: false,
@@ -178,7 +174,7 @@
                 pointer, 'mouseout',
                 pointer, 'mouseover',
 
-            doc,
+            win.document,
 
                 keypress, 'keydown', 'keyup',
 
@@ -527,7 +523,7 @@
 
             if ( options.globals ) Sketch.install( self );
 
-            element = options.element = options.element || doc.createElement( options.type === DOM ? 'div' : 'canvas' );
+            element = options.element = options.element || win.document.createElement( options.type === DOM ? 'div' : 'canvas' );
 
             context = options.context = options.context || (function() {
 
@@ -548,7 +544,7 @@
 
             })();
 
-            ( options.container || doc.body ).appendChild( element );
+            ( options.container || win.document.body ).appendChild( element );
 
             return Sketch.augment( context, options );
         },


### PR DESCRIPTION
Fix #50, by not using `doc.body` until `Sketch.create()` is called.

Note that you still need dom ready for `Sketch.create()` to work, I updated the drawing example to demonstrate this requirement.

Both test cases and demos have been ran successfully to confirm this change is working.

PS: given both `window` and `document` are in global context, I find passing both `this` and `this.document` a bit unnecessary, so clean that up a bit as well.