### PR TITLE
Remove webkitMovement deprecation warning

### DIFF
--- a/js/sketch.js
+++ b/js/sketch.js
@@ -129,6 +129,9 @@
         var object = {};
 
         for ( var key in target ) {
+            
+            if ( key === 'webkitMovementX' || key === 'webkitMovementY' )
+                continue;
 
             if ( isFunction( target[ key ] ) )
 


### PR DESCRIPTION
Starting from Chrome 45, the following warnings appears in the console:
'webkitMovementX' is deprecated. Please use 'movementX' instead.
'webkitMovementY' is deprecated. Please use 'movementY' instead.