### PR TITLE
fix mixed content loading of assets

### DIFF
--- a/examples/css/example.css
+++ b/examples/css/example.css
@@ -1,5 +1,5 @@
 
-@import url(http://fonts.googleapis.com/css?family=Quantico);
+@import url(https://fonts.googleapis.com/css?family=Quantico);
 
 html, body {
 

--- a/examples/css/main.css
+++ b/examples/css/main.css
@@ -1,5 +1,5 @@
 
-@import url(http://fonts.googleapis.com/css?family=Quantico);
+@import url(https://fonts.googleapis.com/css?family=Quantico);
 
 html, body {
 

--- a/examples/three.html
+++ b/examples/three.html
@@ -21,7 +21,7 @@
                 <a href="https://github.com/soulwire/sketch.js" target="_blank">View on Github</a>
             </nav>
         </header>
-        <script src="http://cdnjs.cloudflare.com/ajax/libs/three.js/r58/three.min.js"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r58/three.min.js"></script>
         <script src="../js/sketch.js"></script>
         <script>
 


### PR DESCRIPTION
If the example pages are accessed using `https`, mixed content errors appear. This prevents the rendering of one of the example pages (https://soulwire.github.io/sketch.js/examples/three.html)
<img width="473" alt="Screen Shot 2020-05-20 at 4 48 07 PM" src="https://user-images.githubusercontent.com/20345725/82504948-d61be100-9ab9-11ea-94e2-7485cc216848.png">
