### PR TITLE
Update URLs for https://soulwire.github.io

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,7 +37,7 @@
                 </figcaption>
             </figure>
             <figure>
-                <a href="http://soulwire.github.com/Plasmatic-Isosurface/" target="_blank">
+                <a href="https://soulwire.github.io/Plasmatic-Isosurface/" target="_blank">
                     <img src="examples/img/plasma.jpg">
                 </a>
                 <figcaption>
@@ -55,7 +55,7 @@
                 </figcaption>
             </figure>
             <figure>
-                <a href="http://soulwire.github.com/Muscular-Hydrostats/" target="_blank">
+                <a href="https://soulwire.github.io/Muscular-Hydrostats/" target="_blank">
                     <img src="examples/img/tentacles.jpg">
                 </a>
                 <figcaption>
@@ -64,7 +64,7 @@
                 </figcaption>
             </figure>
             <figure>
-                <a href="http://soulwire.github.com/Crystallisation/" target="_blank">
+                <a href="https://soulwire.github.io/Crystallisation/" target="_blank">
                     <img src="examples/img/crystallization.jpg">
                 </a>
                 <figcaption>
@@ -73,7 +73,7 @@
                 </figcaption>
             </figure>
             <figure>
-                <a href="http://soulwire.github.io/WebGL-GPU-Particles/" target="_blank">
+                <a href="https://soulwire.github.io/WebGL-GPU-Particles/" target="_blank">
                     <img src="examples/img/webgl-particles.jpg">
                 </a>
                 <figcaption>


### PR DESCRIPTION
A few links in index.html point to http://soulwire.github.com, which is outdated. Also made all URLs for soulwire.github.io point to HTTPS.